### PR TITLE
Add support for 64bit ARM and latest binaries.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-REPO_REVISION=20fab815f075645cdb7f320f5addbc1790b18dff
-VERSION=0.2.2.1-$(shell date '+%Y%m%d')
+REPO_REVISION=6871b44b5735645eced8fa5737be4c349862b4b3
+VERSION=0.2.2.2-$(shell date '+%Y%m%d')
 
 LICENSE:
 	curl -s -L https://github.com/philippe44/AirConnect/raw/${REPO_REVISION}/LICENSE -O
@@ -44,7 +44,13 @@ dist/AirConnect-${ARCH}-${VERSION}.spk: target/package.tgz target/scripts target
 
 .PHONY: arm
 arm:
-	$(eval export INFO_ARCH=ipq806x armada370 armadaxp armada375 armada38x alpine alpine4k monaco comcerto2k rtd1296)
+	$(eval export INFO_ARCH=ipq806x armada370 armadaxp armada375 armada38x alpine alpine4k monaco comcerto2k)
+	$(eval export INFO_FIRMWARE=5.0-4458)
+	@true
+
+.PHONY: aarch64
+aarch64:
+	$(eval export INFO_ARCH=rtd1296)
 	$(eval export INFO_FIRMWARE=5.0-4458)
 	@true
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 REPO_REVISION=6871b44b5735645eced8fa5737be4c349862b4b3
-VERSION=0.2.2.2-$(shell date '+%Y%m%d')
+VERSION=0.2.8.0-$(shell date '+%Y%m%d')
 
 LICENSE:
 	curl -s -L https://github.com/philippe44/AirConnect/raw/${REPO_REVISION}/LICENSE -O

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can find the available packages under [Releases](https://github.com/bandesz/
  * **ARMv7**: ipq806x armada370 armadaxp armada375 armada38x alpine alpine4k monaco comcerto2k
  * **ARMv8**: rtd1296
  * **Intel - 32-bit**: x86 cedarview bromolow evansport avoton braswell broadwell apollolake
- * **Intel - 64-bit (DSM 6.0+)**: x86_6
+ * **Intel - 64-bit (DSM 6.0+)**: x86_64
 
 You can check which architecture you have [here](https://www.synology.com/en-uk/knowledgebase/DSM/tutorial/General/What_kind_of_CPU_does_my_NAS_have).
 
@@ -77,7 +77,7 @@ Build a package for only one architecture:
 ARCH=arm make clean build
 ```
 
-Possible values for ARCH: arm, x86, x86-64
+Possible values for ARCH: arm, aarch64, x86, x86-64
 
 You can find the built packages in the dist directory.
 

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-ARCH_LIST="arm x86 x86-64"
+ARCH_LIST="arm aarch64 x86 x86-64"
 
 for arch in ${ARCH_LIST}; do
   export ARCH=${arch}


### PR DESCRIPTION
Realtek RTD1296 CPU, found in DS218play and others, is 64-bit, and
cannot run 'arm' versions of aircast and airupnp. This patch adds 
packaging for aarch64 variants, uses latest AirConnect branch,
and updates the version to 2.2.2.

Successfully tested on Synology DS218play. It should resolve 
issue #26 (Cannot run Package Service) for users with newer devices.